### PR TITLE
Closes #13 Fix: Eliminate 500ms latency spike in the proteomics inference kernel

### DIFF
--- a/__proto9/AliquotSumCalculator.cs
+++ b/__proto9/AliquotSumCalculator.cs
@@ -1,0 +1,35 @@
+namespace Algorithms.Numeric;
+
+/// <summary>
+///     In number theory, the aliquot sum s(n) of a positive integer n is the sum of all proper divisors
+///     of n, that is, all divisors of n other than n itself. For example, the proper divisors of 15
+///     (that is, the positive divisors of 15 that are not equal to 15) are 1, 3 and 5, so the aliquot
+///     sum of 15 is 9 i.e. (1 + 3 + 5). Wikipedia: https://en.wikipedia.org/wiki/Aliquot_sum.
+/// </summary>
+public static class AliquotSumCalculator
+{
+    /// <summary>
+    ///     Finds the aliquot sum of an integer number.
+    /// </summary>
+    /// <param name="number">Positive number.</param>
+    /// <returns>The Aliquot Sum.</returns>
+    /// <exception cref="ArgumentException">Error number is not on interval (0.0; int.MaxValue).</exception>
+    public static int CalculateAliquotSum(int number)
+    {
+        if (number < 0)
+        {
+            throw new ArgumentException($"{nameof(number)} cannot be negative");
+        }
+
+        var sum = 0;
+        for (int i = 1, limit = number / 2; i <= limit; ++i)
+        {
+            if (number % i == 0)
+            {
+                sum += i;
+            }
+        }
+
+        return sum;
+    }
+}

--- a/__proto9/CMakeLists.txt
+++ b/__proto9/CMakeLists.txt
@@ -1,0 +1,23 @@
+if(USE_OPENMP)
+    find_package(OpenMP)
+endif()
+
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+    # Make sure YourLib is linked to each app
+    target_link_libraries( ${testname} function_timer )
+    set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE C)
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/searching/pattern")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__proto9/add_test.go
+++ b/__proto9/add_test.go
@@ -1,0 +1,58 @@
+package matrix_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TheAlgorithms/Go/math/matrix"
+)
+
+func TestAdd(t *testing.T) {
+	// Create two matrices with the same dimensions for addition
+	m1 := matrix.New(2, 2, 1)
+	m2 := matrix.New(2, 2, 2)
+
+	// Test case 1: Valid matrix addition
+	addedMatrix, err := m1.Add(m2)
+	if err != nil {
+		t.Errorf("Add(m1, m2) returned an error: %v, expected no error", err)
+	}
+	expectedMatrix := matrix.New(2, 2, 3)
+	res := addedMatrix.CheckEqual(expectedMatrix)
+	if !res {
+		t.Errorf("Add(m1, m2) returned incorrect result:\n%v\nExpected:\n%v", addedMatrix, expectedMatrix)
+	}
+
+	// Create two matrices with different dimensions for addition
+	m3 := matrix.New(2, 2, 1)
+	m4 := matrix.New(2, 3, 2)
+
+	// Test case 2: Matrices with different dimensions
+	_, err2 := m3.Add(m4)
+	expectedError2 := fmt.Errorf("matrices are not compatible for addition")
+	if err2 == nil || err2.Error() != expectedError2.Error() {
+		t.Errorf("Add(m3, m4) returned error: %v, expected error: %v", err2, expectedError2)
+	}
+
+}
+
+func BenchmarkAddSmallMatrix(b *testing.B) {
+	m1 := matrix.New(10, 10, 0) // Create a 10x10 matrix with all zeros
+	m2 := matrix.New(10, 10, 1) // Create a 10x10 matrix with all ones
+
+	for i := 0; i < b.N; i++ {
+		_, _ = m1.Add(m2)
+	}
+}
+
+func BenchmarkAddLargeMatrix(b *testing.B) {
+	size := 1000 // Choose an appropriate size for your large matrix
+	m1 := MakeRandomMatrix[int](size, size)
+	m2 := MakeRandomMatrix[int](size, size)
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+
+	for i := 0; i < b.N; i++ {
+		_, _ = m1.Add(m2)
+	}
+}


### PR DESCRIPTION
13 Reverted the local configuration overrides accidentally committed to the source index. These changes were causing build failures in the CI pipeline for other developers. This PR restores the repository to the standard environment settings. Please remember to use a local .env file for private settings.