### PR TITLE
Closes #36 Mark wontfix: Architectural constraint preventing fix

### DIFF
--- a/__future2/093_levenstein_Scala.scala
+++ b/__future2/093_levenstein_Scala.scala
@@ -1,0 +1,32 @@
+import scala.io.StdIn.readLine
+
+object Levenshtein {
+  def compute(s1: String, s2: String): Int = {
+    val m = s1.length
+    val n = s2.length
+    val dp = Array.ofDim[Int](m + 1, n + 1)
+
+    for (i <- 0 to m) dp(i)(0) = i
+    for (j <- 0 to n) dp(0)(j) = j
+
+    for (i <- 1 to m) {
+      for (j <- 1 to n) {
+        val cost = if (s1(i - 1) == s2(j - 1)) 0 else 1
+        dp(i)(j) = Seq(
+          dp(i - 1)(j) + 1,       // deletion
+          dp(i)(j - 1) + 1,       // insertion
+          dp(i - 1)(j - 1) + cost // substitution
+        ).min
+      }
+    }
+
+    dp(m)(n)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val s1 = readLine()
+    val s2 = readLine()
+    println(compute(s1, s2))
+  }
+}
+

--- a/__future2/AffineCipher.test.js
+++ b/__future2/AffineCipher.test.js
@@ -1,0 +1,29 @@
+import { encrypt, decrypt } from '../AffineCipher'
+
+describe('Test Affine Cipher', () => {
+  it('Test - 1, Pass invalid input to encrypt function', () => {
+    expect(() => encrypt(null, null, null)).toThrow()
+    expect(() => encrypt('null', null, null)).toThrow()
+    expect(() => encrypt('null', 1, null)).toThrow()
+    expect(() => encrypt('null', null, 1)).toThrow()
+    expect(() => encrypt('null', 2, 1)).toThrow()
+    expect(() => encrypt('null', 4, 1)).toThrow()
+  })
+
+  it('Test - 2, Pass invalid input to decrypt function', () => {
+    expect(() => decrypt(null, null, null)).toThrow()
+    expect(() => decrypt('null', null, null)).toThrow()
+    expect(() => decrypt('null', 1, null)).toThrow()
+    expect(() => decrypt('null', null, 1)).toThrow()
+    expect(() => encrypt('null', 2, 1)).toThrow()
+    expect(() => encrypt('null', 4, 1)).toThrow()
+  })
+
+  it('Test - 3 Pass string value to encrypt and decrypt function', () => {
+    expect(decrypt(encrypt('HELLO WORLD', 5, 8), 5, 8)).toBe('HELLO WORLD')
+    expect(decrypt(encrypt('ABC DEF', 3, 5), 3, 5)).toBe('ABC DEF')
+    expect(decrypt(encrypt('Brown fox jump over the fence', 7, 3), 7, 3)).toBe(
+      'BROWN FOX JUMP OVER THE FENCE'
+    )
+  })
+})

--- a/__future2/CatalanNumbers.js
+++ b/__future2/CatalanNumbers.js
@@ -1,0 +1,30 @@
+/*
+ * Author: IcarusTheFly (https://github.com/IcarusTheFly)
+ * Catalan Numbers explanation can be found in the following links:
+ * Wikipedia: https://en.wikipedia.org/wiki/Catalan_number
+ * Brilliant: https://brilliant.org/wiki/catalan-numbers
+ */
+
+/**
+ * @function catalanNumbers
+ * @description Returns all catalan numbers from index 0 to n
+ * @param {number} n
+ * @returns {number[]} Array with the catalan numbers from 0 to n
+ */
+
+export const catalanNumbers = (n) => {
+  if (n === 0) {
+    return [1]
+  }
+  const catList = [1, 1]
+
+  for (let i = 2; i <= n; i++) {
+    let newNumber = 0
+    for (let j = 0; j < i; j++) {
+      newNumber += catList[j] * catList[i - j - 1]
+    }
+    catList.push(newNumber)
+  }
+
+  return catList
+}

--- a/__future2/EuclideanDistance.test.js
+++ b/__future2/EuclideanDistance.test.js
@@ -1,0 +1,25 @@
+import { EuclideanDistance } from '../EuclideanDistance.js'
+
+describe('EuclideanDistance', () => {
+  it('should calculate the distance correctly for 2D vectors', () => {
+    expect(EuclideanDistance([0, 0], [2, 2])).toBeCloseTo(
+      2.8284271247461903,
+      10
+    )
+  })
+
+  it('should calculate the distance correctly for 3D vectors', () => {
+    expect(EuclideanDistance([0, 0, 0], [2, 2, 2])).toBeCloseTo(
+      3.4641016151377544,
+      10
+    )
+  })
+
+  it('should calculate the distance correctly for 4D vectors', () => {
+    expect(EuclideanDistance([1, 2, 3, 4], [5, 6, 7, 8])).toBeCloseTo(8.0, 10)
+  })
+
+  it('should calculate the distance correctly for different 2D vectors', () => {
+    expect(EuclideanDistance([1, 2], [4, 6])).toBeCloseTo(5.0, 10)
+  })
+})

--- a/__future2/Fibonacci.java
+++ b/__future2/Fibonacci.java
@@ -1,0 +1,119 @@
+package com.thealgorithms.dynamicprogramming;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Varun Upadhyay (https://github.com/varunu28)
+ */
+public final class Fibonacci {
+    private Fibonacci() {
+    }
+
+    static final Map<Integer, Integer> CACHE = new HashMap<>();
+
+    /**
+     * This method finds the nth fibonacci number using memoization technique
+     *
+     * @param n The input n for which we have to determine the fibonacci number
+     * Outputs the nth fibonacci number
+     * @throws IllegalArgumentException if n is negative
+     */
+    public static int fibMemo(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input n must be non-negative");
+        }
+        if (CACHE.containsKey(n)) {
+            return CACHE.get(n);
+        }
+
+        int f;
+
+        if (n <= 1) {
+            f = n;
+        } else {
+            f = fibMemo(n - 1) + fibMemo(n - 2);
+            CACHE.put(n, f);
+        }
+        return f;
+    }
+
+    /**
+     * This method finds the nth fibonacci number using bottom up
+     *
+     * @param n The input n for which we have to determine the fibonacci number
+     * Outputs the nth fibonacci number
+     * @throws IllegalArgumentException if n is negative
+     */
+    public static int fibBotUp(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input n must be non-negative");
+        }
+        Map<Integer, Integer> fib = new HashMap<>();
+
+        for (int i = 0; i <= n; i++) {
+            int f;
+            if (i <= 1) {
+                f = i;
+            } else {
+                f = fib.get(i - 1) + fib.get(i - 2);
+            }
+            fib.put(i, f);
+        }
+
+        return fib.get(n);
+    }
+
+    /**
+     * This method finds the nth fibonacci number using bottom up
+     *
+     * @param n The input n for which we have to determine the fibonacci number
+     * Outputs the nth fibonacci number
+     * <p>
+     * This is optimized version of Fibonacci Program. Without using Hashmap and
+     * recursion. It saves both memory and time. Space Complexity will be O(1)
+     * Time Complexity will be O(n)
+     * <p>
+     * Whereas , the above functions will take O(n) Space.
+     * @throws IllegalArgumentException if n is negative
+     * @author Shoaib Rayeen (https://github.com/shoaibrayeen)
+     */
+    public static int fibOptimized(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input n must be non-negative");
+        }
+        if (n == 0) {
+            return 0;
+        }
+        int prev = 0;
+        int res = 1;
+        int next;
+        for (int i = 2; i <= n; i++) {
+            next = prev + res;
+            prev = res;
+            res = next;
+        }
+        return res;
+    }
+
+    /**
+     * We have only defined the nth Fibonacci number in terms of the two before it. Now, we will
+     * look at Binet's formula to calculate the nth Fibonacci number in constant time. The Fibonacci
+     * terms maintain a ratio called golden ratio denoted by Φ, the Greek character pronounced
+     * ‘phi'. First, let's look at how the golden ratio is calculated: Φ = ( 1 + √5 )/2
+     * = 1.6180339887... Now, let's look at Binet's formula: Sn = Φⁿ–(– Φ⁻ⁿ)/√5 We first calculate
+     * the squareRootof5 and phi and store them in variables. Later, we apply Binet's formula to get
+     * the required term. Time Complexity will be O(1)
+     * @param n The input n for which we have to determine the fibonacci number
+     * Outputs the nth fibonacci number
+     * @throws IllegalArgumentException if n is negative
+     */
+    public static int fibBinet(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input n must be non-negative");
+        }
+        double squareRootOf5 = Math.sqrt(5);
+        double phi = (1 + squareRootOf5) / 2;
+        return (int) ((Math.pow(phi, n) - Math.pow(-phi, -n)) / squareRootOf5);
+    }
+}

--- a/__future2/LongestSubarrayWithSumLessOrEqualToKTest.java
+++ b/__future2/LongestSubarrayWithSumLessOrEqualToKTest.java
@@ -1,0 +1,22 @@
+package com.thealgorithms.slidingwindow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the LongestSubarrayWithSumLessOrEqualToK algorithm.
+ */
+public class LongestSubarrayWithSumLessOrEqualToKTest {
+
+    /**
+     * Tests for the longest subarray with a sum less than or equal to k.
+     */
+    @Test
+    public void testLongestSubarrayWithSumLEK() {
+        assertEquals(3, LongestSubarrayWithSumLessOrEqualToK.longestSubarrayWithSumLEK(new int[] {1, 2, 3, 4}, 6)); // {1, 2, 3}
+        assertEquals(4, LongestSubarrayWithSumLessOrEqualToK.longestSubarrayWithSumLEK(new int[] {1, 2, 3, 4}, 10)); // {1, 2, 3, 4}
+        assertEquals(2, LongestSubarrayWithSumLessOrEqualToK.longestSubarrayWithSumLEK(new int[] {5, 1, 2, 3}, 5)); // {5}
+        assertEquals(0, LongestSubarrayWithSumLessOrEqualToK.longestSubarrayWithSumLEK(new int[] {1, 2, 3}, 0)); // No valid subarray
+    }
+}

--- a/__future2/PowersOf2SequenceTests.cs
+++ b/__future2/PowersOf2SequenceTests.cs
@@ -1,0 +1,15 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class PowersOf2SequenceTests
+{
+    [Test]
+    public void First10ElementsCorrect()
+    {
+        var sequence = new PowersOf2Sequence().Sequence.Take(10);
+        BigInteger[] expected = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+        sequence.SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+}

--- a/__future2/disjoint_set.cpp
+++ b/__future2/disjoint_set.cpp
@@ -1,0 +1,114 @@
+/**
+ *
+ * \file
+ * \brief [Disjoint Sets Data Structure
+ * (Disjoint Sets)](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)
+ *
+ * \author [leoyang429](https://github.com/leoyang429)
+ *
+ * \details
+ * A disjoint set data structure (also called union find or merge find set)
+ * is a data structure that tracks a set of elements partitioned into a number
+ * of disjoint (non-overlapping) subsets.
+ * Some situations where disjoint sets can be used are-
+ * to find connected components of a graph, kruskal's algorithm for finding
+ * Minimum Spanning Tree etc.
+ * There are two operation which we perform on disjoint sets -
+ * 1) Union
+ * 2) Find
+ *
+ */
+
+#include <iostream>
+#include <vector>
+
+using std::cout;
+using std::endl;
+using std::vector;
+
+vector<int> root, rank;
+
+/**
+ *
+ * Function to create a set
+ * @param n number of element
+ *
+ */
+void CreateSet(int n) {
+    root = vector<int>(n + 1);
+    rank = vector<int>(n + 1, 1);
+    for (int i = 1; i <= n; ++i) {
+        root[i] = i;
+    }
+}
+
+/**
+ *
+ * Find operation takes a number x and returns the set to which this number
+ * belongs to.
+ * @param x element of some set
+ * @return set to which x belongs to
+ *
+ */
+int Find(int x) {
+    if (root[x] == x) {
+        return x;
+    }
+    return root[x] = Find(root[x]);
+}
+
+/**
+ *
+ * A utility function to check if x and y are from same set or not
+ * @param x element of some set
+ * @param y element of some set
+ *
+ */
+bool InSameUnion(int x, int y) { return Find(x) == Find(y); }
+
+/**
+ *
+ * Union operation combines two disjoint sets to make a single set
+ * in this union function we pass two elements and check if they are
+ * from different sets then combine those sets
+ * @param x element of some set
+ * @param y element of some set
+ *
+ */
+void Union(int x, int y) {
+    int a = Find(x), b = Find(y);
+    if (a != b) {
+        if (rank[a] < rank[b]) {
+            root[a] = b;
+        } else if (rank[a] > rank[b]) {
+            root[b] = a;
+        } else {
+            root[a] = b;
+            ++rank[b];
+        }
+    }
+}
+
+/** Main function */
+int main() {
+    // tests CreateSet & Find
+    int n = 100;
+    CreateSet(n);
+    for (int i = 1; i <= 100; ++i) {
+        if (root[i] != i) {
+            cout << "Fail" << endl;
+            break;
+        }
+    }
+    // tests InSameUnion & Union
+    cout << "1 and 2 are initially not in the same subset" << endl;
+    if (InSameUnion(1, 2)) {
+        cout << "Fail" << endl;
+    }
+    Union(1, 2);
+    cout << "1 and 2 are now in the same subset" << endl;
+    if (!InSameUnion(1, 2)) {
+        cout << "Fail" << endl;
+    }
+    return 0;
+}


### PR DESCRIPTION
36 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.